### PR TITLE
fixing stalling waiting for maxParallel channel within rollback path

### DIFF
--- a/db/mysql/setter.go
+++ b/db/mysql/setter.go
@@ -208,6 +208,9 @@ func (m *PasswordSetter) setAll(ctx context.Context, creds db.NewPassword, actio
 
 		if action == rollback_password && !m.dbs[i].set {
 			log.Printf("%s: new password was not set, skip rollback", m.dbs[i].hostname)
+			// Sending to maxParallel so that we don't wait indefinitely
+			// for maxParallel channel in the rollback path.
+			m.maxParallel <- true
 			continue
 		}
 


### PR DESCRIPTION
### Description

Currently rollback path will stall indefinitely if we exhaust maxParallel buffered channel size.  

Test with maxParallel of 1 (existing code)

<img width="1489" alt="image" src="https://github.com/square/password-rotation-lambda/assets/119374224/e602fc62-e1c5-44f9-9d47-bd5ebf452d6a">

### Testing

Rolled out changes  (new code) with maxParallel size of 1.   Password rotation lambda was able to rollback successfully.

<img width="1530" alt="image" src="https://github.com/square/password-rotation-lambda/assets/119374224/4f701b5d-9b4d-4f55-b563-570fdf631b03">
