### PR TITLE
Set password fixes

### DIFF
--- a/db/mysql/setter.go
+++ b/db/mysql/setter.go
@@ -279,6 +279,7 @@ func (m *PasswordSetter) setAll(ctx context.Context, creds db.NewPassword, actio
 			}
 		case verify_password:
 			if db.verifyError != nil {
+				log.Printf("ran into verify error: %v", db.verifyError)
 				errCount += 1
 			}
 		case rollback_password:

--- a/db/mysql/setter.go
+++ b/db/mysql/setter.go
@@ -292,7 +292,6 @@ func (m *PasswordSetter) setAll(ctx context.Context, creds db.NewPassword, actio
 			}
 		case verify_password:
 			if db.verifyError != nil {
-				log.Printf("ran into verify error: %v", db.verifyError)
 				errCount += 1
 			}
 		case rollback_password:

--- a/db/mysql/setter.go
+++ b/db/mysql/setter.go
@@ -160,11 +160,6 @@ func (m *PasswordSetter) Rollback(ctx context.Context, creds db.NewPassword) err
 		log.Printf("Rollback return: %dms", d.Milliseconds())
 	}()
 
-	// Reset flags and errors between attempts to rollback the password to prevent
-	// potential false positives caused by two successive runs.
-	for i, db := range m.dbs {
-		m.dbs[i] = dbInstance{hostname: db.hostname}
-	}
 	swapCreds := db.NewPassword{
 		Current: creds.New,
 		New:     creds.Current,

--- a/rotate.go
+++ b/rotate.go
@@ -381,7 +381,6 @@ func (r *Rotator) SetSecret(ctx context.Context, event map[string]string) error 
 		Current: curCred,
 		New:     newCred,
 	}
-	debugSecret("SetSecret db credentials: %+v", creds)
 
 	// Check to see if DB is already set to Pending password.
 	// This can happen if there's a previous run that did not complete successfully.
@@ -421,7 +420,7 @@ func (r *Rotator) SetSecret(ctx context.Context, event map[string]string) error 
 			Username: prevUsername,
 			Password: prevPassword,
 		}
-		debugSecret(fmt.Sprintf("AWSPREVIOUS secret used to verify: %v", prevCred))
+
 		if err := r.db.VerifyPassword(ctx, db.NewPassword{Current: prevCred, New: prevCred}); err != nil {
 			r.event.Receive(Event{
 				Name: EVENT_BEGIN_PASSWORD_ROLLBACK,
@@ -441,7 +440,6 @@ func (r *Rotator) SetSecret(ctx context.Context, event map[string]string) error 
 		}
 		log.Println("DB is set to AWSPREVIOUS version of secret")
 	}
-	debugSecret(fmt.Sprintf("creds used for setPassword : %v", creds))
 
 	// Have user-provided PasswordSetter set database password to new value.
 	// Normally, this is when the database password actually changes.

--- a/rotate.go
+++ b/rotate.go
@@ -399,7 +399,7 @@ func (r *Rotator) SetSecret(ctx context.Context, event map[string]string) error 
 	// Verify that credentials are valid before attempting to update secrets
 	log.Println("Verifying if AWSCURRENT version of secret is valid")
 	if err := r.db.VerifyPassword(ctx, db.NewPassword{Current: curCred, New: curCred}); err != nil {
-		log.Print("ERROR: DB is not set to AWSCURRENT version of secret, attempting to verify AWSPREVIOUS version: %v", err)
+		log.Printf("ERROR: DB is not set to AWSCURRENT version of secret, attempting to verify AWSPREVIOUS version: %v", err)
 		// the current version of secret is out of sync with db.  check if db is in sync with
 		// the previous version of the secret
 		_, prevVals, err := r.getSecret(AWSPREVIOUS)

--- a/rotate.go
+++ b/rotate.go
@@ -415,9 +415,9 @@ func (r *Rotator) SetSecret(ctx context.Context, event map[string]string) error 
 		_, prevVals, err := r.getSecret(AWSPREVIOUS)
 		if err != nil {
 			r.event.Receive(Event{
-				Name: EVENT_ERROR,
+				Name: EVENT_BEGIN_PASSWORD_ROLLBACK,
 				Step: "setSecret",
-				Time: r.startTime,
+				Time: time.Now(),
 			})
 			return fmt.Errorf("current version of credential in secret manager is out of sync with db; "+
 				" unable to retreive previous version of the credential. %v", err)
@@ -429,9 +429,9 @@ func (r *Rotator) SetSecret(ctx context.Context, event map[string]string) error 
 		}
 		if err := r.db.VerifyPassword(ctx, db.NewPassword{Current: prevCred, New: prevCred}); err != nil {
 			r.event.Receive(Event{
-				Name: EVENT_ERROR,
+				Name: EVENT_BEGIN_PASSWORD_ROLLBACK,
 				Step: "setSecret",
-				Time: r.startTime,
+				Time: time.Now(),
 			})
 			return fmt.Errorf("all versions of credentials in secret manager is out of sync with db; "+
 				" unable to update secret. %v", err)

--- a/rotate.go
+++ b/rotate.go
@@ -381,7 +381,7 @@ func (r *Rotator) SetSecret(ctx context.Context, event map[string]string) error 
 		Current: curCred,
 		New:     newCred,
 	}
-
+	debugSecret("db credentials: %+v", creds)
 	// Check to see if DB is already set to Pending password.
 	// This can happen if there's a previous run of the lambda crashed
 	// in TestSecret or FinishSecret steps.
@@ -455,7 +455,7 @@ func (r *Rotator) SetSecret(ctx context.Context, event map[string]string) error 
 		Step: "setSecret",
 		Time: r.startTime,
 	})
-	debugSecret("db credentials: %+v", creds)
+
 	if err := r.db.SetPassword(ctx, creds); err != nil {
 		// Roll back to original password since setting the new password failed.
 		// Depending on how the PasswordSetter is configured, this might be a no-op.


### PR DESCRIPTION
### Description
Handle two additional edge cases in SetSecret steps.    

1. DB is set to AWSPENDING version prior to starting SetSecret step
2. DB is set to AWSPREVIOUS version prior to starting SetSecret step

As illustrated in AWS python [examples](https://github.com/aws-samples/aws-secrets-manager-rotation-lambdas/blob/master/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py#L156-L195) DB and Secret Manager can be in mismatch at the start of SetSecret step. 

### Testing

1. Password Set to AWSPENDING version
<img width="2454" alt="image" src="https://github.com/square/password-rotation-lambda/assets/119374224/5c3d1f3c-1995-48d3-a863-01b6c00c72de">

<img width="1881" alt="image" src="https://github.com/square/password-rotation-lambda/assets/119374224/aed322b5-725d-436e-9703-15a2634501ad">

4. DB set to AWSPREVIOUS version
<img width="2545" alt="Screenshot 2023-08-22 at 7 08 44 AM" src="https://github.com/square/password-rotation-lambda/assets/119374224/525353b8-d318-4ab7-adb5-34a4a660e4cc">

 
<img width="1925" alt="image" src="https://github.com/square/password-rotation-lambda/assets/119374224/6fdaa679-bd15-4c0f-ad3c-7eac854656c2">
